### PR TITLE
SDPA Improvements and Fixes

### DIFF
--- a/picos/problem.py
+++ b/picos/problem.py
@@ -6907,7 +6907,7 @@ class Problem(object):
             pass
         else:
             printnodual = False
-            indy, indzl, indzs = 0, 0, 0
+            indy, indzl, indzq, indzs = 0, 0, 0, 0
             ieq = self.cvxoptVars['Gl'].size[0]
             neq = (dims['l'] - ieq) // 2
             if neq > 0:
@@ -6916,9 +6916,8 @@ class Problem(object):
             else:
                 soleq = None
             if ieq + neq > 0:
-                indzs = 1
-            else:
-                indzs = 0
+                indzq = indzs = 1
+            indzs += len(dims['q'])
             for k, consk in enumerate(self.constraints):
                 # Equality
                 if consk.typeOfConstraint == 'lin=':
@@ -6936,9 +6935,9 @@ class Problem(object):
                     indzl += consSz
                 # SOCP constraint [Rotated or not]
                 elif consk.typeOfConstraint[2:] == 'cone':
-                    M = dual_solution[indzs]
+                    M = dual_solution[indzq]
                     duals.append(cvx.matrix([np.trace(M), -2*M[-1,:-1].T]))
-                    indzs += 1
+                    indzq += 1
                 # SDP constraint
                 elif consk.typeOfConstraint[:3] == 'sdp':
                     duals.append(dual_solution[indzs])

--- a/picos/problem.py
+++ b/picos/problem.py
@@ -6805,8 +6805,9 @@ class Problem(object):
         import os
         from subprocess import call
         tstart = time.time()
-        params = [self.sdpa_executable, self.sdpa_dats_filename,
-                  self.sdpa_out_filename] + self.options['sdpa_params'].split()
+        params = [self.sdpa_executable, '-ds', self.sdpa_dats_filename,
+                  '-o', self.sdpa_out_filename] + \
+                  self.options['sdpa_params'].split()
         if self.options['verbose'] >= 1:
             call(params)
         else:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name='PICOS',


### PR DESCRIPTION
This allows users to specify custom SDPA executables and parameters, and fixes a bug where SOC dual variables are incorrectly recovered as SDP duals if the SDP constraint appears before the SOC constraint.