### PR TITLE
Add GLPK support.

### DIFF
--- a/picos/problem.py
+++ b/picos/problem.py
@@ -3378,7 +3378,7 @@ class Problem(object):
         import swiglpk as glpk
 
         if self.options['verbose'] > 0:
-            print('Building a GLPK problem instance.', flush=True)
+            print("Building a GLPK problem instance.")
             glpk.glp_term_out(glpk.GLP_ON)
         else:
             glpk.glp_term_out(glpk.GLP_OFF)
@@ -3528,6 +3528,9 @@ class Problem(object):
                 glpk.glp_set_mat_row(p, index, numSetColumns, setColumns_glpk, setCoefficients_glpk)
 
             rowOffset += numRows
+
+        if self.options['verbose'] > 0:
+            print("GLPK problem instance built.")
 
     #-----------
     # mosek tool
@@ -5646,6 +5649,12 @@ class Problem(object):
         #       For MIPs:
         #           *_tech, *_heur, ps_tm_lim, *_cuts, cb_size, binarize
 
+        if verbosity > 0:
+            print('-----------------------------------')
+            print('    GNU Linear Programming Kit')
+            print('-----------------------------------')
+            sys.stdout.flush()
+
         # Attempt to solve the problem.
         import time
         startTime = time.time()
@@ -7525,6 +7534,7 @@ class Problem(object):
                 'mosek7',
                 'mosek6',
                 'zibopt',
+                'glpk',
                 'cvxopt',
                 'smcp']
         elif tp in ('QCQP,QP'):
@@ -7553,7 +7563,9 @@ class Problem(object):
                 'zibopt',
                 'cvxopt',
                 'smcp']
-        elif tp in ('MIP', 'MIQCP', 'MIQP'):
+        elif tp == 'MIP':
+            order = ['cplex', 'gurobi', 'mosek7', 'mosek6', 'zibopt', 'glpk']
+        elif tp in ('MIQCP', 'MIQP'):
             order = ['cplex', 'gurobi', 'mosek7', 'mosek6', 'zibopt']
         elif tp == 'Mixed (SOCP+quad)':
             order = ['mosek7', 'mosek6', 'cplex', 'gurobi', 'cvxopt', 'smcp']

--- a/picos/tools.py
+++ b/picos/tools.py
@@ -1675,6 +1675,12 @@ def available_solvers():
     except ImportError:
         pass
     try:
+        import swiglpk as gl
+        lst.append('glpk')
+        del gl
+    except ImportError:
+        pass
+    try:
         import smcp as sm
         lst.append('smcp')
         del sm


### PR DESCRIPTION
Uses [swiglpk](https://github.com/biosustain/swiglpk) by @biosustain.

Note that `test_picos.py` fails the MIP test because GLPK supports the `maxit` option only with Simplex, and thus throws an exception when the option is specified alongside a MIP currently. (Whether an exception as opposed to a warning is necessary in this case is of course up to debate.) If the exception is not raised, then the MIP test passes.

Feedback is of course appreciated. Particular questions are:
- Should verbosity set to `0` really suppress all outputs, even warnings and errors? For this purpose I added `-1`, which is currently only understood by GLPK, though.
- I'm not entirely sure why (and whether) the sign swaps when retrieving the duals are correct like this, here I have been mimicking other retrieval functions until GLPK produced the same results. Is this necessary purely due to properties of the simplex tableu method or also due to internal conventions of GLPK and/or PICOS in some way?