### PR TITLE
Attempt to fix #54.

### DIFF
--- a/picos/expression.py
+++ b/picos/expression.py
@@ -1936,6 +1936,8 @@ class Norm(Expression):
         if isinstance(exp, AffinExp):
             if self.exp.size != (1, 1):
                 return Constraint('SOcone', None, self.exp, exp)
+            elif not self.exp.is_real():
+                return Constraint('SOcone', None, self.exp.real // self.exp.imag, exp)
             else:
                 cons = (self.exp // -self.exp) < (exp // exp)
                 if exp.is1():


### PR DESCRIPTION
Upper bounding the norm of a complex scalar now results in a second
order cone constraint.

Unfortunately the provided example runs into a "math domain error"
inside CVXOPT's ConeLP solver, so it is hard to tell if the fix is
correct.